### PR TITLE
Removing library path to use system libraries, and correcting the Exe…

### DIFF
--- a/files/scsmd_systemd
+++ b/files/scsmd_systemd
@@ -3,9 +3,7 @@ Description=LogRhythm System Monitor Agent
 After=network.target
 
 [Service]
-Environment=LR_HOME=/opt/logrhythm/scsm
-Environment=LD_LIBRARY_PATH=/opt/logrhythm/scsm/lib
-ExecStart=/opt/logrhythm/scsm/bin/scsmd
+ExecStart=/opt/logrhythm/scsm/bin/scsmd /opt/logrhythm/scsm
 SuccessExitStatus=15
 Restart=on-failure
 


### PR DESCRIPTION
fixes issues: 
opt/logrhythm/scsm/lib/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /opt/logrhythm/scsm/bin/scsmd)
and
incorrect ExecStart command